### PR TITLE
Add support for idem's Sourcing Suite

### DIFF
--- a/release/eSixCafe.user.css
+++ b/release/eSixCafe.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           eSix Café
 @namespace      mandorinn
-@version        1.3.7
+@version        1.3.8
 @description    A muted and easy on the eyes style for e621. Big credits to Faucet for the bug reports so far, thank you!
 @author         mandorinn [(www.mandorinn.dev)], faucet [(https://e621.net/users/601225)]
 @updateURL		https://github.com/mandorinn/eSix-Cafe/raw/main/release/eSixCafe.user.css
@@ -3850,7 +3850,7 @@ if themep == classic {
 	}
 }
 
-@-moz-document url-prefix("https://e621.net/extensions"), url-prefix("https://e926.net/extensions") {
+@-moz-document url-prefix("https://e621.net/extensions") {
 	/* idem's Sourcing Suite */
 	h1 {
 		background-color: var(--bg);

--- a/release/eSixCafe.user.css
+++ b/release/eSixCafe.user.css
@@ -3849,3 +3849,20 @@ if themep == classic {
 		margin-left: .05rem;
 	}
 }
+
+@-moz-document url-prefix("https://e621.net/extensions"), url-prefix("https://e926.net/extensions") {
+	/* idem's Sourcing Suite */
+	h1 {
+		background-color: var(--bg);
+		color: var(--content-link) !important;
+	}
+	.setting_section{
+		background-color: var(--bg) !important;
+	}
+	.setting_description, .setting_values{
+		color: var(--base-text);
+	}
+	.setting_header, .settings_table_head{
+		color: var(--content-link) !important;
+	}
+}


### PR DESCRIPTION
Not sure if this is in project scope since it's a third party tool and all, if you don't think so just reject the PR. I did try and do it in a way that it won't interrupt other parts of the website though.

This effects the pseudo-page at /extensions that the script adds for configuration.

How it normally looks:
![image](https://user-images.githubusercontent.com/102884856/184947129-7d72c298-d89b-4f5c-abd7-001f18cba595.png)

How it looks with eSix Café, without the changes:
![image](https://user-images.githubusercontent.com/102884856/184948630-df5141ea-f9d9-43b2-a4f7-352bd6d82b83.png)

How it looks with the changes:
![image](https://user-images.githubusercontent.com/102884856/184949684-4a662ae6-4104-4a9c-8029-23c5460a4d94.png)