### PR TITLE
Changes for rating buttons on post edit

### DIFF
--- a/release/eSixCafe.user.css
+++ b/release/eSixCafe.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           eSix Café
 @namespace      mandorinn
-@version        1.3.9
+@version        1.4.0
 @description    A muted and easy on the eyes style for e621. Big credits to Faucet for the bug reports so far, thank you!
 @author         mandorinn [(www.mandorinn.dev)], faucet [(https://e621.net/users/601225)]
 @updateURL		https://github.com/mandorinn/eSix-Cafe/raw/main/release/eSixCafe.user.css
@@ -3108,7 +3108,7 @@ if themep == classic {
 	button.rating-s.active {
 		background-color: var(--favorite-button)!important;
 	}
-	.collection_radio_buttons{
+	form.simple_form div.collection-radio-buttons input + label{
 		color: var(--base-text)!important;
 	}
 	.radio_buttons:not(:checked)+label {

--- a/release/eSixCafe.user.css
+++ b/release/eSixCafe.user.css
@@ -3108,6 +3108,21 @@ if themep == classic {
 	button.rating-s.active {
 		background-color: var(--favorite-button)!important;
 	}
+	.collection_radio_buttons{
+		color: var(--base-text)!important;
+	}
+	.radio_buttons:not(:checked)+label {
+		background-color: var(--bg-300)!important;
+	}
+	#post_rating_e:checked+label {
+		background-color: var(--remove-favorite)!important;
+	}	
+	#post_rating_q:checked+label {
+		background-color: var(--warn-button)!important;
+	}
+	#post_rating_s:checked+label {
+		background-color: var(--favorite-button)!important;
+	}
 	/* Site map */
 
 	#a-site-map {


### PR DESCRIPTION
Ugh, this one isn't ready to merge. _(no version number change in the commit for that reason)_

A recent e621 update added these buttons when editing a post
![image](https://user-images.githubusercontent.com/102884856/185146585-32021ddd-8005-48ce-a4a0-ffd571dd63b2.png)

I tried to make it match these buttons on the upload page
![image](https://user-images.githubusercontent.com/102884856/185144075-3c1be2cf-9605-4587-a35b-892456449fa1.png)

This was as far as I could get - I can't seem to make the text white because the actual styling is `color: #000!important`
![image](https://user-images.githubusercontent.com/102884856/185146049-189dd7fd-7561-43ee-9bb4-14d8be171c65.png)

Not sure if there's some special way to override the black text or if we'll have to just deal with it being like that.