### PR TITLE
Some tweaks to mobile userpages

### DIFF
--- a/release/eSixCafe.user.css
+++ b/release/eSixCafe.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           eSix Café
 @namespace      mandorinn
-@version        1.4.3
+@version        1.4.4
 @description    A muted and easy on the eyes style for e621. Big credits to Faucet for the bug reports so far, thank you!
 @author         mandorinn [(www.mandorinn.dev)], faucet [(https://e621.net/users/601225)]
 @updateURL		https://github.com/mandorinn/eSix-Cafe/raw/main/release/eSixCafe.user.css
@@ -3773,6 +3773,11 @@ if themep == classic {
 			border-radius: 4px;
 		}
 	}
+	@media (max-width: 800px) {	
+		div#c-users div#a-show .about-section .about-piece {
+			margin: 0 0 1em 0;
+		}
+	}
 	}
 	/* Regular userpage */
 	div#page:not([enhancements="true"]) {
@@ -3782,6 +3787,12 @@ if themep == classic {
 		border-radius: var(--avatar-border-radius);
 		aspect-ratio: 1/1;
 		outline: 5px solid var(--elements-highlight) !important;
+		}
+		@media (max-width: 800px) {	
+			div#c-users div#a-show .profile-avatar {
+				margin: 0.5em auto 1em auto;
+				width: fit-content;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Some small changes to make user pages look a little better on mobile.

### Tweak the margins to look a little nicer on the about section (RE621)
![image](https://user-images.githubusercontent.com/102884856/186188696-ce68fb02-6a1c-4058-97ce-de53b7c04e24.png)
Old (left) and new (right)

### Center the profile image and add margins (Vanilla)
![image](https://user-images.githubusercontent.com/102884856/186189729-d430c22c-78ab-409b-9e43-e968a3f69985.png)

