### PR TITLE
Fix oversized blacklist thumbnails on the forum

### DIFF
--- a/release/eSixCafe.user.css
+++ b/release/eSixCafe.user.css
@@ -2667,7 +2667,7 @@ if themep == classic {
 				}
 			}
 		}
-		.avatar, .blacklisted {
+		.avatar, .avatar .blacklisted {
 			display: flex;
 			align-items: center;
 			justify-content: center;

--- a/release/eSixCafe.user.css
+++ b/release/eSixCafe.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           eSix Café
 @namespace      mandorinn
-@version        1.4.7
+@version        1.4.8
 @description    A muted and easy on the eyes style for e621. Big credits to Faucet for the bug reports so far, thank you!
 @author         mandorinn [(www.mandorinn.dev)], faucet [(https://e621.net/users/601225)]
 @updateURL		https://github.com/mandorinn/eSix-Cafe/raw/main/release/eSixCafe.user.css


### PR DESCRIPTION
Reported by Dripen Arn on [topic #33090](https://e621.net/forum_topics/33090) - the thumbnails in posts were being effected by the selector intended for blacklisted user avatars.