### PR TITLE
Update to fontawesome 6

### DIFF
--- a/release/eSixCafe.user.css
+++ b/release/eSixCafe.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           eSix Café
 @namespace      mandorinn
-@version        1.6.0
+@version        1.6.1
 @description    A muted and easy on the eyes style for e621. Big credits to Faucet for the bug reports so far, thank you!
 @author         mandorinn [(www.mandorinn.dev)], faucet [(https://e621.net/users/601225)]
 @updateURL		https://github.com/mandorinn/eSix-Cafe/raw/main/release/eSixCafe.user.css
@@ -1008,7 +1008,7 @@ if themep == classic {
 		padding: 0 0 0rem 0;
 		border-radius:0;
 	}
-	.fas {
+	.fa-solid {
 		color: var(--header-link);
 		transition: var(--header-link-transition);
 		&:hover {
@@ -2227,13 +2227,13 @@ if themep == classic {
 				display:flex;
 				align-items:center;
 				justify-content: space-around;
-				.far {
+				.fa-regular {
 					margin-right: .25rem;
 				}
 			}
 			li.forum-post-vote-block {
 				gap: .5rem;
-				.far {
+				.fa-regular {
 					margin-right: 0;
 				}
 			}


### PR DESCRIPTION
The upgrade to fontawesome 6 with https://github.com/e621ng/e621ng/commit/29c7b80f3a42f028d7c8a279d257a9c248fc190e broke some styling because the `fas` and `far` classes were renamed to `fa-solid` and `fa-regular` respectively.